### PR TITLE
Avoid messages when mappings are executed

### DIFF
--- a/plugin/QFEnter.vim
+++ b/plugin/QFEnter.vim
@@ -66,8 +66,8 @@ augroup END
 " functions
 function! s:RegisterMapping(keymap, wintype, opencmd)
 	for key in a:keymap
-		execute 'nnoremap <buffer> '.key.' :call QFEnter#OpenQFItem("'.a:wintype.'","'.a:opencmd.'",0)<CR>'
-		execute 'vnoremap <buffer> '.key.' :call QFEnter#OpenQFItem("'.a:wintype.'","'.a:opencmd.'",1)<CR>'
+		execute 'nnoremap <silent> <buffer> '.key.' :call QFEnter#OpenQFItem("'.a:wintype.'","'.a:opencmd.'",0)<CR>'
+		execute 'vnoremap <silent> <buffer> '.key.' :call QFEnter#OpenQFItem("'.a:wintype.'","'.a:opencmd.'",1)<CR>'
 	endfor
 endfunction
 


### PR DESCRIPTION
When hitting enter on the quickfix window the correspondent function call is displayed on the status line.
While this could be useful for debugging, there is no point displaying it to the user.
