### PR TITLE
Fix always open quickfix window when 'open in a new tab' command is executed inside the location list.

### DIFF
--- a/autoload/QFEnter.vim
+++ b/autoload/QFEnter.vim
@@ -255,7 +255,11 @@ function! s:OpenQFItem(wintype, opencmd, qflnum)
 	" restore quickfix window when tab mode
 	if a:wintype==#'t'
 		if g:qfenter_enable_autoquickfix
-			exec modifier 'copen'
+			if isloclist
+				exec modifier 'lopen'
+			else
+				exec modifier 'copen'
+			endif
 			exec qfresize
 			call winrestview(qfview)
 			wincmd p


### PR DESCRIPTION
Fix #14 