### PR TITLE
Restore focus in orig win before new tab to match split behavior

### DIFF
--- a/autoload/QFEnter.vim
+++ b/autoload/QFEnter.vim
@@ -163,6 +163,11 @@ function! s:OpenQFItem(tabwinfunc, qfopencmd, qflnum)
 
 	" restore quickfix window when tab mode
 	if target_newtabwin==#'nt'
+		" to match split behavior, jump back to before qf in orig win
+		clearjumps
+		tabprev
+		wincmd p
+		tabnext
 		if g:qfenter_enable_autoquickfix
 			if isloclist
 				exec s:modifier 'lopen'


### PR DESCRIPTION
@yssl thank you so much for QFEnter!
I use this change so that after opening qf entry in a new tab and going back to previous tab has focus in orig window which matches how it behaves with an h/v split.
What do you think ?
thx,
-m
