### PR TITLE
Fix prevtabwin_policy tag name

### DIFF
--- a/doc/QFEnter.txt
+++ b/doc/QFEnter.txt
@@ -153,7 +153,8 @@ For example, you can prevent opening items in NERDTree and Tagbar windows using 
 <
 You can check *filetype* of the current window using `:echo &filetype`.
 
-*g:qfenter_exclude_filetypes*
+
+*g:qfenter_prevtabwin_policy*
 This option determines which window on which tab should have focus when the `wincmd p` is executed after opening a quickfix item.
 
 * 'qf': The previous window and tab are set to the quickfix window from which the QFEnter open command is invoked and the tab the window belongs to.


### PR DESCRIPTION
`g:qfenter_exclude_filetypes` was duplicated, which produced

```
Error detected while processing command line:
E154: Duplicate tag "g:qfenter_exclude_filetypes" in file qfenter/doc/QFEnter.txt
Failed to build help tags!
```

when rebuilding the help tags