### PR TITLE
Add option to use next window when excluded filetype detected

### DIFF
--- a/autoload/QFEnter.vim
+++ b/autoload/QFEnter.vim
@@ -150,6 +150,16 @@ function! s:OpenQFItem(tabwinfunc, qfopencmd, qflnum)
 		echoerr 'QFEnter: '''.g:qfenter_prevtabwin_policy.''' is an undefined value for g:qfenter_prevtabwin_policy.'
 	endif
 
+	if g:qfenter_excluded_action==#'next'
+		" move to next usable window if possible
+		let c = 0
+		let wincount = winnr('$')
+		while ( index(g:qfenter_exclude_filetypes, &ft) >= 0 && c < wincount )
+			wincmd w
+			let c = c + 1
+		endwhile
+	endif
+
 	let excluded = 0
 	for ft in g:qfenter_exclude_filetypes
 		if ft==#&filetype

--- a/doc/QFEnter.txt
+++ b/doc/QFEnter.txt
@@ -154,6 +154,16 @@ For example, you can prevent opening items in NERDTree and Tagbar windows using 
 You can check *filetype* of the current window using `:echo &filetype`.
 
 
+*g:qfenter_excluded_action*
+Action to take when selected window contains an excluded filetype.
+
+* 'error': Show an error message and do not open the file.
+* 'next': Open the file in the next usable window, otherwise fall back to quickfix default (split above)
+
+Default: >
+    let g:qfenter_excluded_action = 'error'
+
+
 *g:qfenter_prevtabwin_policy*
 This option determines which window on which tab should have focus when the `wincmd p` is executed after opening a quickfix item.
 

--- a/plugin/QFEnter.vim
+++ b/plugin/QFEnter.vim
@@ -72,6 +72,13 @@ if !exists('g:qfenter_exclude_filetypes')
 	let g:qfenter_exclude_filetypes = []
 endif
 
+if !exists('g:qfenter_excluded_action')
+	" Action to take when the selected window contains and exclude filetype
+	" 'error': Show an error message and do not open the file (Default)
+	" 'next': Open the file in the next usable window, fall back to quickfix default if no usable windows (split above)
+	let g:qfenter_excluded_action = 'error'
+endif
+
 if !exists('g:qfenter_prevtabwin_policy')
 	" This option determines which window on which tab should have focus when the `wincmd p` is executed after opening a quickfix item.
 	" 'qf': The previous window and tab are set to the quickfix window from which the QFEnter open command is invoked and the tab the window belongs to.


### PR DESCRIPTION
I find it more useful to move to the next usable window rather than show an error when the selected window contains an excluded filetype. To achieve this I have added a custom function and CR mapping in my `.vimrc`, but it's kinda fugly...

```
" Tell QFEnter to skip some filetypes when choosing window to open
" Note: plugin required because vim only reuses normal buffers when opening
" files from quickfix windows, which does not work well with bufexplorer etc.
let g:qfenter_exclude_filetypes = ['nerdtree', 'tagbar', 'scratch']

" Customise QFEnter CR mapping to move to next usable window rather than
" simply echo an error when previous window matches an excluded filetype
" FIXME: fork QFEnter and add a feature to support this kind of behaviour
let g:qfenter_custom_map_list = []
call add(g:qfenter_custom_map_list, {
  \'tabwinfunc': 'QFEnterWin',
  \'qfopencmd': 'cc',
  \'keepfocus': 0,
  \'keys': ['<CR>'],
  \})
function! QFEnterWin()
  wincmd p
  let c = 0
  let wincount = winnr('$')
  while ( index(g:qfenter_exclude_filetypes, &ft) >= 0 && c < wincount )
    wincmd w
    let c = c + 1
  endwhile
  return [tabpagenr(), winnr(), 1, '']
endfunc
```

It seems like this might be a useful optional feature, so I've added a `g:qfenter_excluded_action` option in this PR to allow it. Set the option to 'next' to tell QFEnter to find the next usable window, falling back to the quickfix default (split above) when no window found.

The fallback could be changed to show an error, by adding a check to see if we're back in the quickfix window after trying to find a usable window, e.g. 

```
if &filetype==#'qf'
  echo "QFEnter: No usable windows found, all windows contain excluded filetypes"
  return
endif
```

but IMHO it is more useful to open the file somewhere rather than simply error.