### PR TITLE
Comment out visual mode mappings in QFEnter.vim

### DIFF
--- a/plugin/QFEnter.vim
+++ b/plugin/QFEnter.vim
@@ -135,13 +135,13 @@ function! s:RegisterKeymap()
 		let keepfocus = s:cmd_action_map[cmd][2]
 		for key in keylist
 			execute 'nnoremap <silent> <buffer> '.key.' :call QFEnter#OpenQFItem("'.tabwinfunc.'","'.qfopencmd.'","'.keepfocus.'",0)<CR>'
-			execute 'vnoremap <silent> <buffer> '.key.' :call QFEnter#OpenQFItem("'.tabwinfunc.'","'.qfopencmd.'","'.keepfocus.'",1)<CR>'
+			" execute 'xnoremap <silent> <buffer> '.key.' :call QFEnter#OpenQFItem("'.tabwinfunc.'","'.qfopencmd.'","'.keepfocus.'",1)<CR>'
 		endfor
 	endfor
 	for cfitem in g:qfenter_custom_map_list
 		for key in cfitem.keys
 			execute 'nnoremap <silent> <buffer> '.key.' :call QFEnter#OpenQFItem("'.cfitem.tabwinfunc.'","'.cfitem.qfopencmd.'","'.cfitem.keepfocus.'",0)<CR>'
-			execute 'vnoremap <silent> <buffer> '.key.' :call QFEnter#OpenQFItem("'.cfitem.tabwinfunc.'","'.cfitem.qfopencmd.'","'.cfitem.keepfocus.'",1)<CR>'
+			" execute 'xnoremap <silent> <buffer> '.key.' :call QFEnter#OpenQFItem("'.cfitem.tabwinfunc.'","'.cfitem.qfopencmd.'","'.cfitem.keepfocus.'",1)<CR>'
 		endfor 
 	endfor
 endfunction


### PR DESCRIPTION
For example, one could map one of these to `o` as it is of little use in the qf window, but then in visual mode jumping is no longer possible; in any event, maps are meant to be used in normal mode?